### PR TITLE
Fix behaviour around large buffers and early reader completion

### DIFF
--- a/tests/TurnerSoftware.Aqueduct.Tests/PipeBifurcationTests.cs
+++ b/tests/TurnerSoftware.Aqueduct.Tests/PipeBifurcationTests.cs
@@ -73,6 +73,33 @@ public class PipeBifurcationTests
 	}
 
 	[TestMethod]
+	public async Task SingleTarget_ReaderCompletesEarly_Success()
+	{
+		var source = new Pipe();
+		var buffer = new byte[16];
+		await source.Writer.WriteAsync(buffer);
+		var targetReaderHasCompleted = false;
+
+		var bifurcationTask = PipeBifurcation.BifurcatedReadAsync(
+			source.Reader,
+			new BifurcationSourceConfig(minReadBufferSize: -1),
+			new BifurcationTargetConfig(
+				async (Stream reader, CancellationToken cancellationToken) =>
+				{
+					var buffer = new byte[1];
+					await reader.ReadAsync(buffer, cancellationToken);
+					targetReaderHasCompleted = true;
+				}
+			)
+		);
+
+		await source.Writer.WriteAsync(buffer);
+		await source.Writer.CompleteAsync();
+		await bifurcationTask;
+		targetReaderHasCompleted.Should().BeTrue();
+	}
+
+	[TestMethod]
 	public async Task MultiTarget_DefaultConfig_Success()
 	{
 		var source = CreateSource("Test Value");

--- a/tests/TurnerSoftware.Aqueduct.Tests/PipeBifurcationTests.cs
+++ b/tests/TurnerSoftware.Aqueduct.Tests/PipeBifurcationTests.cs
@@ -89,7 +89,11 @@ public class PipeBifurcationTests
 					var buffer = new byte[1];
 					await reader.ReadAsync(buffer, cancellationToken);
 					targetReaderHasCompleted = true;
-				}
+				},
+				//These are set to exaggerate the problem where exiting early
+				//still has the pipe being fed bytes till the point it blocks
+				blockAfter: 16,
+				resumeAfter: 8
 			)
 		);
 


### PR DESCRIPTION
There are two problems this fixes:
- The buffer may be bigger than the destination span resulting to an exception writing to the target
- If a target finishes early (eg. doesn't want to read all the bytes), the pipe for the target is still being fed bytes and can block waiting for bytes to be read

These are fixed by:
- Slicing the buffer appropriately for the destination span
- Having the pipe reader complete after the reader task finishes